### PR TITLE
Add immich-photo-manager to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
-- [immich-photo-manager](https://github.com/drolosoft/immich-photo-manager) - Manage your self-hosted Immich photo library through conversation — search photos with natural language, create geographic albums from GPS data, detect duplicates across import sources, run health audits, and browse results in interactive HTML galleries. 21 MCP tools, 11 skills, 5 commands.
+- [immich-photo-manager](https://github.com/drolosoft/immich-photo-manager) - Manage your self-hosted Immich photo library through conversation — search photos with natural language, create geographic albums from GPS data, detect duplicates across import sources, run health audits, and browse results in interactive HTML galleries. 22 MCP tools, 11 skills, 5 commands.
 
 ### Frontend & Design
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
-- [immich-photo-manager](https://github.com/drolosoft/immich-photo-manager) - Manage your self-hosted Immich photo library through conversation — search photos with natural language, create geographic albums from GPS data, detect duplicates across import sources, run health audits, and browse results in interactive HTML galleries. 22 MCP tools, 11 skills, 5 commands.
+- [immich-photo-manager](https://github.com/drolosoft/immich-photo-manager) - Manage your self-hosted Immich photo library through conversation — search photos with natural language, create geographic albums from GPS data, detect duplicates, manage people and faces, trash cleanup, run health audits, and browse results in interactive HTML galleries. 36 MCP tools, 11 skills, 5 commands.
 
 ### Frontend & Design
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 500+ services.
+- [immich-photo-manager](https://github.com/drolosoft/immich-photo-manager) - Manage your self-hosted Immich photo library through conversation — search photos with natural language, create geographic albums from GPS data, detect duplicates across import sources, run health audits, and browse results in interactive HTML galleries. 21 MCP tools, 11 skills, 5 commands.
 
 ### Frontend & Design
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Integrations
 
 - [connect-apps](./connect-apps) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
+- [immich-photo-manager](https://github.com/drolosoft/immich-photo-manager) - Manage your self-hosted Immich photo library through conversation: natural language and OCR search, geographic albums from GPS data, duplicate detection, people and faces, metadata repair, video frames and PDF photobooks, interactive HTML galleries. 94 MCP tools, 13 skills, 5 commands, tested live on Immich 2.x and 3.x.
 - [kaggle-skill](https://github.com/shepsci/kaggle-skill) - Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection.
 
 ### Frontend & Design


### PR DESCRIPTION
Adds immich-photo-manager to Integrations.

connect-apps connects Claude to hosted services; this one connects it to something you host yourself, an Immich photo library (Immich is at 97k+ stars on GitHub). You ask in plain words and it does the API work: "show me the photos from Italy", "find the picture with the train ticket" (OCR), "create albums for everywhere I have traveled", "find duplicates", "who is in this photo", "make me a PDF of this trip".

The plugin carries 94 MCP tools (search, albums, duplicates, people and faces, metadata, memories, stacks, partners, video frames, PDF export, tags, trash, notes on each asset), 13 skills for the longer workflows, and 5 commands (`/cleanup`, `/create-album`, `/my-travels`, `/immich-status`, `/setup-immich-photo-manager`). Nothing is deleted without asking; trash first, permanent delete only when you say so.

It runs live against real Immich 2.7.5 and 3.1.0 before every release, all tools over MCP, and the kit for that is in `tests/live/`. MIT, Python 3.10+, plugin scanner 100/100. Same server also runs with `uvx` or as a Docker image (`ghcr.io/drolosoft/immich-photo-manager`) for other MCP clients.
