### PR TITLE
Add memoir plugin - Git for Claude Code's memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [memoir](https://github.com/zhangfengcdt/memoir) - Git-versioned, taxonomy-structured memory for Claude Code. Branch, commit, and time-travel your agent's memory with semantic paths (`profile.coding.style`) instead of opaque vector stores. Auto-captures session context via SessionStart/UserPromptSubmit/Stop hooks; recall by path with `/memoir:recall`. ([Website](https://www.memoir-ai.dev/))
 
 ### Companion & Personality
 


### PR DESCRIPTION
  ## Summary
  - Adds [memoir](https://github.com/zhangfengcdt/memoir) to the **Developer Productivity** section as an external-link entry, following the precedent set by `kaggle-skill`, `backlog`, and `MyVibe`.
  - memoir is a Git-versioned, taxonomy-structured memory plugin for Claude Code: semantic paths (e.g. `profile.coding.style`) instead of opaque vector stores, branch/commit/time-travel via a `memoir` CLI, and SessionStart / UserPromptSubmit / Stop hooks that auto-capture session context. Recall by path with `/memoir:recall`.
  - README-only change. `marketplace.json` is left untouched since it only catalogs in-repo plugins.

git repo: https://github.com/zhangfengcdt/memoir
project page: https://www.memoir-ai.dev/