### PR TITLE
Add LoreConvo and LoreDocs (Developer Productivity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [LoreConvo](https://github.com/labyrinth-analytics/loreconvo) - Persistent session memory MCP server. Automatically saves and retrieves conversation context across Claude Code, web chat, and other surfaces. Per-session metadata, tags, project namespacing, and FTS5 search. Free tier: 50 sessions.
+- [LoreDocs](https://github.com/labyrinth-analytics/loredocs) - Knowledge vault MCP server. Organizes durable project docs, specs, and guides with FTS5 search and tagging. Per-vault Pro gating, embedding-based auto-linking, and cross-project context loading. Free tier: 3 vaults.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adding two MCP servers to the **Developer Productivity** section:

- **LoreConvo** ([labyrinth-analytics/loreconvo](https://github.com/labyrinth-analytics/loreconvo)) — persistent session memory MCP server with FTS5 search, project namespacing, and cross-surface context recall (Claude Code, web chat, other clients).
- **LoreDocs** ([labyrinth-analytics/loredocs](https://github.com/labyrinth-analytics/loredocs)) — knowledge vault MCP server with per-vault tagging, embedding-based auto-linking, and cross-project context loading.

Both have been live on the Anthropic plugin marketplace since 2026-04-27 and are real, tested tools (not placeholder/experimental projects). They address use cases not yet covered by the section's existing entries: LoreConvo focuses on durable session memory across surfaces, and LoreDocs focuses on long-lived project knowledge organization.

Checklist:
- [x] Addresses a real use case
- [x] Doesn't duplicate existing functionality
- [x] Follows the template structure (matching the format of other externally-hosted entries like CCHub, context-mode, codebase-graph)
- [x] Has been tested (published on Anthropic marketplace; both have free tiers anyone can install and try)