### PR TITLE
Add Ocul-PM — local-first work journal plugin for coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [Ocul-PM](https://github.com/bunhine0452/Ocul-PM) - Local-first work journal for AI coding agents: a hook bridge, 4 MCP tools and 5 skills record what Claude Code does as markdown journals and living plans in `.oculpm/`, with planner dispatch and 3-depth plans. Optional macOS companion app (Tauri 2) renders timelines, per-entry diffs and retros. ([Website](https://oculpm.com))
 
 ### Companion & Personality
 


### PR DESCRIPTION
## What

Adds **Ocul-PM** to the *Developer Productivity* section — a local-first work journal for AI coding agents, installable as a Claude Code plugin in two lines:

```
/plugin marketplace add bunhine0452/Ocul-PM
/plugin install oculpm@oculpm
```

## Why it fits the guidelines

- **Real use case**: agents write a markdown journal entry per unit of work into the project's `.oculpm/` directory (hook bridge + 4 MCP tools + 5 skills), so "what did Claude change last week and why" stays answerable. Per-entry diffs let you verify claimed fixes.
- **Not duplicative**: journaling + living plans + dispatch is a different surface from existing entries — backlog is task management, CCHub is an ecosystem manager; Ocul-PM records and verifies the work itself. Complementary to both.
- **Tested**: the plugin's read/write contract (tracked-repos-only, no network in hooks) is pinned by docs and invariant tests — see [plugin contract](https://github.com/bunhine0452/Ocul-PM/blob/main/docs/claude-integration/06-plugin-contract.md). `claude plugin validate` passes.
- Optional macOS companion app (Tauri 2, MIT) renders the journals as timelines, diffs and retros. Free forever for individuals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)