### PR TITLE
Add Talivia Agent Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Developer Productivity
 
 - [CCHub](https://github.com/Moresl/cchub) - Desktop app for managing the Claude Code ecosystem — MCP marketplace, config profiles, skills & plugins browser, workflow templates, security audit. Built with Tauri v2 + React + Rust.
+- [talivia-agent-kit](https://github.com/talivia-group/agent) - Claude Code plugin, Agent Skill, CLI, and MCP server for installing revenue-first website analytics, verifying live events, and connecting traffic to payment attribution.
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
 - [skill-bus](./skill-bus) - The skill for connecting skills. Wire context, conditions, and other skills into any skill invocation — declaratively, without modification. Zero dependencies.


### PR DESCRIPTION
Talivia is revenue-first website analytics installed and verified by AI agents through MCP.

Official resources:
- Source: https://github.com/talivia-group/agent
- Hosted OAuth MCP: `https://talivia.com/mcp`
- npm: `@talivia/agent` version `0.1.0`
- Official MCP Registry: `io.github.talivia-group/agent`
- Integration guide: https://talivia.com/ai-agent-kit

The server helps agents install tracking, verify live events, connect payment attribution through a secure browser flow, and identify which referrers, campaigns, pages, and customer journeys become revenue.

This adds the Talivia plugin and Agent Skill to Developer Productivity.