### PR TITLE
Add suede-creator-skills to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
-- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - Marketplace of 70 Agent Skills for Claude Code and Codex: code review and A–F grading, AI evals, CI gates, design, copy, SEO, and app shipping.
+- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - Marketplace of 71 Agent Skills for Claude Code and Codex: code review and A–F grading, AI evals, CI gates, design, copy, SEO, and app shipping.
 
 ### Companion & Personality
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - Marketplace of 70 Agent Skills for Claude Code and Codex: code review and A–F grading, AI evals, CI gates, design, copy, SEO, and app shipping.
 
 ### Companion & Personality
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
-- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - Marketplace of 71 Agent Skills for Claude Code and Codex: code review and A–F grading, AI evals, CI gates, design, copy, SEO, and app shipping.
+- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - Marketplace of open-source Agent Skills for Claude Code and Codex: code review and A–F grading, AI evals, CI gates, design, copy, SEO, and app shipping.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) — 71 open-source Agent Skills for Claude Code and Codex.

Covers code review and A–F grading, AI evals, CI gates, design, copy, SEO/AEO/GEO, iOS/Android shipping, and creator rights.

Single line added in the matching section, following the surrounding entry format.