### PR TITLE
Add UIZZE to Frontend & Design plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Frontend & Design
 
 - [frontend-design](./frontend-design) - Create distinctive, production-grade interfaces. Avoids generic "AI slop" with bold typography, unique color palettes, and creative layouts.
+- [UIZZE](https://github.com/uizze/uizze) - Stop generic UI before it ships with an anti-UI-slop Claude Code plugin, free MCP preview, and hard UI Slop Gate grounded in 800,000+ real web and iOS screens.
 - [artifacts-builder](./artifacts-builder) - Suite of tools for creating elaborate, multi-component HTML artifacts using React, Tailwind CSS, and shadcn/ui.
 - [theme-factory](./theme-factory) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [canvas-design](./canvas-design) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters and static pieces.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Frontend & Design
 
 - [frontend-design](./frontend-design) - Create distinctive, production-grade interfaces. Avoids generic "AI slop" with bold typography, unique color palettes, and creative layouts.
-- [UIZZE](https://github.com/uizze/uizze) - Stop generic UI before it ships with an anti-UI-slop Claude Code plugin, free MCP preview, and hard UI Slop Gate grounded in 800,000+ real web and iOS screens.
+- [UIZZE](https://github.com/uizze/uizze) - Stop generic UI before it ships with a free anti-UI-slop Skill and conservative GitHub Action for coding agents. The optional authenticated MCP provides find_ui_references and find_ui_materials over 800,000+ real web and iOS screens.
 - [artifacts-builder](./artifacts-builder) - Suite of tools for creating elaborate, multi-component HTML artifacts using React, Tailwind CSS, and shadcn/ui.
 - [theme-factory](./theme-factory) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [canvas-design](./canvas-design) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters and static pieces.


### PR DESCRIPTION
Adds UIZZE to the Frontend & Design section as a Claude Code plugin for preventing generic UI before it ships.

- anti-UI-slop skill
- free MCP preview and hard UI Slop Gate
- grounded in 800,000+ real web and iOS screens
- maintained public source: https://github.com/uizze/uizze
- website: https://uizze.com