### PR TITLE
Add usage-limits to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [usage-limits](https://github.com/ridelink0/claude-code-usage-limits) - Reads how much of your 5-hour and weekly Claude Code limit is left, converts it into turns of headroom rather than a percentage, and plans work to fit inside it. Detects plan tier, breaks spend down by model and project, and adds a status line.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds `usage-limits` under Developer Productivity.

It reads the 5-hour and weekly usage percentages Claude Code already caches locally, cross-references the session transcripts to work out what one percentage point costs on that account, and reports the remaining headroom as turns of work rather than a bare percentage. The point is planning rather than display: it names which window binds first, says whether that window resets before you run out, and if it does not, what to cut.

It also detects plan tier (Pro, Max 5x, Max 20x, Team, Enterprise), breaks the window down by model and by project, and has a `--status` mode for the status line that skips the transcript scan so it stays fast enough to run on every redraw.

MIT, no dependencies, and nothing leaves the machine. 66 tests, passes `claude plugin validate --strict`.

https://github.com/ridelink0/claude-code-usage-limits