### PR TITLE
Add WebMCP Kit plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [WebMCP Kit](https://github.com/nekuda-ai/webmcp-kit) - Adds WebMCP tools to existing web apps through a visual Explorer: maps user journeys, proposes tools for approval, implements them, and verifies each one in a real browser.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [WebMCP Kit](https://github.com/nekuda-ai/webmcp-kit) to the Developer Productivity section.

WebMCP Kit is a coding-agent plugin that maps a web app's user journeys in a visual Explorer, proposes WebMCP tools for approval, implements them through the app's own logic, and verifies each tool in a real browser.

The contribution follows the repository's accepted README-only pattern for externally maintained plugins.