### PR TITLE
Add chamnan to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [chamnan](https://github.com/ArcticFox2029/chamnan) - Keeps a repository's engineering context as markdown committed beside the code: an architecture index the agent reads instead of scanning files, plus the work state, the decisions behind it, and the procedures you keep re-deriving. Repository-local, no network, Python stdlib, MIT.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## What this adds

One line under **Developer Productivity**, linking [chamnan](https://github.com/ArcticFox2029/chamnan) (MIT, 3 stars, actively maintained).

## What it does

chamnan keeps a repository's engineering context as markdown committed beside the code, so an agent stops rediscovering the same work every session:

- an **architecture index** the agent reads instead of scanning files
- the **work state** and the **decisions** behind it, which normally die with the session
- the **procedures and tools** you keep re-deriving

Repository-local, no network calls, Python standard library only.

## Measured, not claimed

On a polyglot test corpus of 2,365 files, 11,560,484 tokens of source become a 51,937-token index, of which roughly 3,000 reach each session. The README documents how each figure was measured, and states plainly where a different measurement method gives a different ratio.

## Why a link rather than a vendored folder

Following [context-mode](https://github.com/mksglu/claude-context-mode), [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) and [backlog](https://github.com/backloghq/backlog) in the same section — a copy here would drift from upstream, and this way the listing always points at the maintained version.

Happy to reformat or move it to a different section if you would rather have it elsewhere.