### PR TITLE
Add Concord MCP to developer productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [concord-mcp](https://github.com/Get-Concord-AI/concord-mcp) - Claude Code plugin and MCP server for live communication and shared work-state across Claude Code, Codex, Cursor, Gemini CLI, and Grok Build, with collision-aware scope claims and evidence-rich handoffs.
 
 ### Companion & Personality
 


### PR DESCRIPTION
## Summary

Adds Concord MCP to **Developer Productivity**. The project ships a tested Claude Code plugin and local MCP server that lets Claude Code communicate and coordinate repository work with Codex, Cursor, Gemini CLI, and Grok Build.

The bundled Claude plugin is at `plugin/concord-relay/` and is installed by `concord setup`. Concord is MIT licensed and actively maintained.

Disclosure: this submission was prepared by a coding agent on behalf of the project maintainer.