### PR TITLE
Add kindle-highlights to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [kindle-highlights](https://github.com/l3a0/claude-plugins) - Export every Kindle highlight for a book to one verbatim, location-cited Markdown file — recovers the highlights Amazon's export limit truncates or hides, using the Mac Kindle app's synced positions plus local OCR of the Cloud Reader. macOS only, MIT.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [l3a0/claude-plugins](https://github.com/l3a0/claude-plugins) — the kindle-highlights skill exports every Kindle highlight for a book into one verbatim, location-cited Markdown file, including the highlights Amazon's export limit truncates or hides (recovered from the Mac Kindle app's synced annotation positions plus local Apple Vision OCR of the Cloud Reader's rendered pages).

- MIT licensed; macOS-only constraint stated up front
- Proven on four real books: 2,432 highlights, 815 export-blocked, all recovered
- Install: `claude plugin marketplace add l3a0/claude-plugins` then `claude plugin install l3a0@l3a0`

Entry matches the section's existing format.