### PR TITLE
Add computer-use plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
 
+- [computer-use](https://github.com/ridelink0/claude-computer-use) - Codex-style computer use for Windows and macOS. Drives desktop apps through the accessibility tree instead of screenshots, so targeting is exact, survives display scaling, and costs about 20x fewer tokens. Can work on the same desktop while you keep working, telling your input apart from its own.
+
 ### Companion & Personality
 
 - [claude-familiar](https://github.com/yaniv-golan/claude-familiar) - Enhance Claude Code's `/buddy` companion with personality, mood, lore, and interactive commands (fortune, roast, haiku, focus timer). Mood shifts automatically on tool success/failure. Extensible — other plugins can layer traits and lore via `"x-familiarExtensions"` in their `plugin.json`.


### PR DESCRIPTION
Adds **computer-use** under Developer Productivity: Codex-style computer use for Windows and macOS that drives desktop apps through the accessibility tree instead of screenshots (exact targeting, DPI-proof, ~20x cheaper in tokens), and can work on the same desktop while you keep working.

Repo: https://github.com/ridelink0/claude-computer-use — MIT. Single-line addition.