### PR TITLE
Add kettle (Developer Productivity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [kettle](https://github.com/ChiHanLu/kettle) - Put the kettle on and walk away. Sound cues for Claude Code hook events, so you can leave the terminal and still know what happened: it finished, it needs permission, it's been waiting on you — and when the turn died on an API error (rate limit / overload), which looks exactly like still working. 11 events each independently on/off, random pools, per-event volume, speech, quiet hours, custom audio. macOS/Windows/Linux, zero dependencies.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [kettle](https://github.com/ChiHanLu/kettle) under **Developer Productivity**.

> Renamed from `claude-sounds` mid-review — the name was already taken in the official community directory. Same one-line PR, updated.

**The use case:** long Claude Code runs mean staring at a terminal. kettle lets you walk away. The part nothing else does: when the turn **dies** on an API rate limit or overload, a silent terminal looks identical to a working one — I checked the `hooks.json` of all eleven sound/notification plugins in the community directory and none of them cover `StopFailure`.

- 11 hook events, each independently switchable: `Stop`, `Notification:permission_prompt`, `Notification:idle_prompt`, `SubagentStop`, `StopFailure`, `PostToolUseFailure`, `PermissionDenied`, `PreCompact`, `SessionStart`, `SessionEnd`, `TaskCompleted`
- macOS / Windows / Linux, **zero dependencies** — `afplay` / PowerShell `MediaPlayer` / `paplay`→`ffplay`→`mpv`→`aplay`
- Portable sound aliases so one config works on any machine; your own files go in `~/.claude/kettle/sounds/`
- Random pools, per-event volume, speech output, quiet hours, macOS focus suppression
- Installs **silent** — nothing plays until the user runs `/kettle on`
- Playback is detached, hot path returns in ~30 ms, so blocking hooks like `Stop` never stall a turn
- MIT · `claude plugin validate` clean · CI selftests on ubuntu/macos/windows · README in English / 繁體中文 / 简体中文

Against the contributing criteria: real use case, does not duplicate anything in the list, and tested (selftest + 3-platform CI).

One line added to README.md, nothing else touched.