### PR TITLE
Add interview-sim plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [interview-sim](https://github.com/chrisjacksonn/interview-sim) - Feed it a posting and 2 minutes later your IDE looks like the real screen: original question, starter file, tests, and a clock that does not negotiate.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds interview-sim to Developer Productivity. It is a Claude Code plugin I built for timed technical-screen practice: paste a job posting, it researches that company's round, writes an original question, and runs the sitting in your editor against hidden tests with a hard stop. MIT, zero dependencies.