### PR TITLE
Add html2wp — HTML to a verified WordPress block theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [canvas-design](./canvas-design) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters and static pieces.
 - [senior-frontend](./senior-frontend) - React/Next.js/TypeScript development patterns with bundle analysis, component generation, and accessibility best practices.
 - [frontend-developer](./frontend-developer) - Frontend development specialist agent for building modern web interfaces.
+- [html2wp](https://github.com/iOSDevSK/html2wp-cc-plugin) - Converts HTML to a WordPress block theme. Lovable, Bolt, v0, Claude artifacts or hand-written pages become a standalone theme that runs with no plugin, verified against the original at three viewport widths.
 
 ### Git & Version Control
 


### PR DESCRIPTION
Adds **html2wp** to Development Engineering.

It converts a static HTML site — or anything that builds to one (Lovable, Bolt,
v0, Claude artifacts, Next.js export, Vite, Astro, shadcn, hand-written pages) —
into a standalone WordPress block theme. The markup you shipped is the markup
that ships: no page builder rebuilds your sections, so the result is 1:1 rather
than an approximation of the design.

What makes it different from the usual HTML→WordPress converters is that it
checks its own output. Every page is composed side by side with its original at
1440, 820 and 390 pixels wide, then the generated theme is installed into a
throwaway WordPress in Docker and driven there before anything is handed over.
The last stage is a person reading every page pair, because the numeric gates
pass things a person would reject.

The delivered theme is standalone — pages, blog, forms, menus, SEO and redirects
are its own code, it needs no plugin to run, and it contacts no server at
runtime.

**Six live examples**, each running on WordPress with its admin open
(`demo` / `demo`): [bruce](https://bruce.html2wp.dev/) ·
[amanda](https://amanda.html2wp.dev/) · [terra](https://terra.html2wp.dev/)
(WooCommerce) · [georgia](https://georgia.html2wp.dev/) ·
[soria](https://soria.html2wp.dev/) · [claire](https://claire.html2wp.dev/)

```
/plugin marketplace add iOSDevSK/html2wp-cc-plugin
/plugin install html2wp@html2wp
```

Free tier is open to everyone with no key and no sign-up: three conversions of
up to five pages each. Requires Node 20+, Python with Playwright, and Docker —
the browser and the container are what do the checking.

Docs: https://html2wp.dev/docs · Walkthroughs:
[Lovable](https://html2wp.dev/blog/lovable-to-wordpress/) ·
[a design made in Claude](https://html2wp.dev/blog/claude-design-to-wordpress/)
