### PR TITLE
Add coder-eval to Code Quality & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.
+- [coder-eval](https://github.com/UiPath/coder_eval) - Behavioral evals for skills and coding agents. Scores skill-activation precision/recall, gates CI.
 
 ### Backend & Architecture
 


### PR DESCRIPTION
Adds **coder-eval** to `Code Quality & Testing`.

```
- [coder-eval](https://github.com/UiPath/coder_eval) - Behavioral evals for skills and coding agents. Scores skill-activation precision/recall, gates CI.
```

**Disclosure:** I maintain this project. Happy to reword the entry, shorten it, or move it to a different section if you read it as a better fit elsewhere — just say which and I'll push the change.

### What it is

Most quality tooling for plugins checks the *files* — schema, structure, lint. coder-eval checks the *behavior*: given a labelled set of prompts, does the skill actually fire when it should, and stay quiet when it shouldn't? It reports that as suite-level precision / recall / F1 and can fail a GitHub Actions run when the numbers drop, so skill-description regressions get caught in review rather than in production.

It runs the same suite against different agents (Claude Code, Codex, OpenCode, Antigravity), which is how you tell "the skill is wrong" apart from "this harness didn't route to it."

- Repo: https://github.com/UiPath/coder_eval — Apache-2.0, 118★
- Docs: https://coder-eval.com/docs
- The plugin itself: `plugins/coder-eval/` — 6 skills (`/coder-eval:init`, `:check-skill`, `:task`, `:lint-tasks`, `:analyze`, `:ci`), installable with `/plugin marketplace add UiPath/coder_eval`

### Against your three requirements

- **Addresses a real use case** — plugin and skill authors currently have no way to know whether a `description:` edit helped or hurt activation. This measures it.
- **Doesn't duplicate existing functionality** — closest neighbour in the section is [AgentLint](https://github.com/0xmariowu/AgentLint), which statically lints a repo for agent compatibility. This is complementary and not overlapping: AgentLint reads your files, coder-eval runs your skill against labelled prompts and scores what actually happened.
- **Tested** — the project's own CI runs its suites on every PR, including a published composite Action that dogfoods the gate.

### One note on the diff

I've added an **external link** rather than vendoring a plugin folder, which I know differs from step 2 of your contributing steps. Two reasons: it matches how the recently merged external plugins are listed (AgentLint, CCHub, backlog, security-sweep, maestro-orchestrate and others), and a vendored copy would pin a snapshot that drifts from the released version as the plugin updates. **If you'd rather have the folder in-repo, say so and I'll add it in this same PR** — along with the `marketplace.json` / `.claude-plugin/marketplace.json` entries, which I've left untouched since they currently list only the 24 in-repo plugins.

Diff is one line. Thanks for maintaining the list.
