### PR TITLE
Add HyperGrok under Trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Ask Claude to send you a test email. If you receive it, Claude is now connected 
   - [Documentation & Security](#documentation--security)
   - [Developer Productivity](#developer-productivity)
   - [Companion & Personality](#companion--personality)
+  - [Trading](#trading)
 - [Getting Started](#getting-started)
 - [Contributing](#contributing)
 - [Resources](#resources)
@@ -166,6 +167,10 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [nano-banana](https://github.com/Ibrahim-3d/nano-banana-claude-plugin) - Google Gemini image generation plugin. Text-to-image, text-guided image editing, style transfer, 4K output, search grounding, and multi-reference composition — all from a single `/genimage` command. Powered by `gemini-2.5-flash-image` and `gemini-3-pro-image-preview`.
 - [taisly-agent-kit](https://github.com/taisly/agent) - Claude Code plugin, skill, SDK, CLI, and MCP server for publishing short-form videos to TikTok, Instagram Reels, YouTube Shorts, X, and Facebook through Taisly.
+
+### Trading
+
+- [hypergrok](https://github.com/galleonlabs/hypergrok-trading-desk) - Seven-agent Hyperliquid trading desk for Claude Code and Grok Bot. Research, risk, execution, and review. Approve every trade by ticket id.
 
 ## Getting Started
 


### PR DESCRIPTION
External plugin link under Trading. Plugin stays in its own repo.

https://github.com/galleonlabs/hypergrok-trading-desk

Ships `.claude-plugin/plugin.json`. README-only change; no vendored plugin folder.
