### PR TITLE
Add oddyssey plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [MyVibe](https://www.myvibe.so) - Instant deployment to live URLs with `/myvibe:publish`.
 - [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) - Automated AWS cost optimization with 173 checks across EC2, RDS, S3, Lambda, and more. ML-powered recommendations and real pricing from AWS API.
 - [Manifest](https://github.com/mnfst/manifest) - Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. Includes Claude Code [skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided setup. Self-hosted, OTLP ingestion, 28+ LLM models. ([Website](https://manifest.build))
+- [oddyssey](https://github.com/using-system/oddyssey) - CLI toolbox for Observability-Driven Development: instruments OpenTelemetry, observes local or remote runs (Grafana, Datadog, Dynatrace, Azure Monitor, CloudWatch, Splunk) through metrics/traces/logs/profiles, and turns findings into the next dev wave — reports committed to `.odd/` as the loop's memory.
 
 ### Documentation & Security
 


### PR DESCRIPTION
## Summary

Adds [oddyssey](https://github.com/using-system/oddyssey) to the DevOps & Performance section — a CLI toolbox for Observability-Driven Development (ODD): instrument OpenTelemetry, observe a running service (local Grafana stack or a remote backend — Grafana, Datadog, Dynatrace, Azure Monitor, CloudWatch, Splunk), and turn findings into the next spec-driven wave. Observation and instrumentation reports are committed to `.odd/` in the observed repo, so the loop accumulates knowledge across runs instead of starting blind each time.

- Real use case: complements Spec-Driven Development with an observe → fix → verify loop, evidenced by real worked examples in the repo's own README (the project instruments and observes its own MCP server).
- No duplicate in the list.
- MIT licensed, public repository, packaged via [APM](https://microsoft.github.io/apm/) for Claude Code, Copilot CLI, Cursor, Codex, Gemini, and other coding agents, plus a native Claude Code plugin marketplace.

## Test plan

- [x] Entry follows the existing bullet format and section style
- [x] Placed in DevOps & Performance, alongside the other observability/cost-tracking entries (Manifest, aws-cost-saver)