### PR TITLE
Add cc-oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [cc-oracle](https://github.com/exPardus/cc-oracle) - Makes a Claude Code session consult a read-only, best-model oracle subagent the moment it is unsure or stuck: a SessionStart doctrine, a Stop-hook safety net that catches stated uncertainty, and a trigger for three consecutive tool failures. Compiled hook, zero config, no runtime dependencies, Windows/macOS/Linux.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [cc-oracle](https://github.com/exPardus/cc-oracle) to the Developer Productivity section. It makes a Claude Code session consult a read-only, best-model oracle subagent the moment it is unsure or stuck, via a SessionStart doctrine, a Stop-hook safety net that catches stated uncertainty, and a trigger on three consecutive tool failures (one agent, two hooks, compiled hook, zero config, no runtime dependencies, MIT). The entry is a single README.md line in the list's existing `[name](url) - description` format, like the other externally hosted plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECmkx5GpzVXxUXqfpjKC9Q
