### PR TITLE
Add omen

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 - [AgentLint](https://github.com/0xmariowu/AgentLint) - Lint your repo for AI agent compatibility. 33 evidence-backed checks across 5 dimensions. Claude Code plugin.
 - [code-review](./code-review) - Comprehensive code review with best practices, patterns, and improvement suggestions.
+- [omen](https://github.com/panbanda/omen) - Code analysis plugins (omen-development, omen-reporting) backed by a Rust MCP server: complexity, tech debt, dead code, hotspots and HTML health reports.
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.


### PR DESCRIPTION
Adds a link-only entry for the Omen plugin marketplace to Code Quality & Testing, in alphabetical order, the same way AgentLint is listed.

Omen is a Rust CLI and MCP server that measures code health for AI coding agents: cyclomatic and cognitive complexity, self-admitted tech debt, stubs, dead code, git churn and hotspots, clone detection, defect prediction, semantic search and a composite health score across Go, Rust, Python, TypeScript, JavaScript, Java, C, C++, C#, Ruby, PHP and Bash. It ships Claude Code plugins (omen-development, omen-reporting) and a GitHub Action for PR risk comments. Apache-2.0, released weekly, installs with Homebrew or Docker. https://github.com/panbanda/omen Install with `/plugin marketplace add panbanda/omen`.