### PR TITLE
Add ultracode-live-engineer to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Skills tell your agent **how** to work. An MCP Gateway gives it secure access to
 
 Composio [MCP Gateway](https://composio.dev/mcp-gateway) provides a single MCP endpoint for 1,000+ integrations with built-in authentication, team-based access controls, audit logs, and production-ready reliability.
 
-
 ### 1. Clone & Run
 
 ```bash
@@ -149,6 +148,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 
 ### Developer Productivity
 
+- [ultracode-live-engineer](https://github.com/AlvaroRaul7/ultracode-live-engineer) - Unattended Claude Code loop that reviews Slack-tagged PRs and works your Jira backlog end to end — self-paced, running phases and tickets in parallel, until you stop it. Escalates anything ambiguous back to a human via a Jira comment + Slack DM instead of guessing.
 - [CCHub](https://github.com/Moresl/cchub) - Desktop app for managing the Claude Code ecosystem — MCP marketplace, config profiles, skills & plugins browser, workflow templates, security audit. Built with Tauri v2 + React + Rust.
 
 - [developer-growth-analysis](./developer-growth-analysis) - Analyzes your recent Claude Code chat history to identify coding patterns, development gaps, and curates personalized learning resources.
@@ -214,6 +214,7 @@ Want to add your plugin?
 4. Submit a pull request
 
 Please ensure your plugin:
+
 - Addresses a real use case
 - Doesn't duplicate existing functionality
 - Follows the template structure


### PR DESCRIPTION
## Summary

Adds [ultracode-live-engineer](https://github.com/AlvaroRaul7/ultracode-live-engineer) to the Developer Productivity section.

It's an unattended Claude Code loop that:
- Scans a Slack channel for `@mention` + PR link, runs a full multi-agent review, and approves outright when only nits survive
- Works a Jira backlog end to end — root-causes, implements, tests, and opens a PR for each ticket, each in its own isolated git worktree
- Fixes review feedback / failing checks on its own open PRs
- Never guesses: anything ambiguous is escalated via a Jira comment + On Hold transition + Slack DM, and resumes automatically once a human replies
- Runs phases (Slack review / PR follow-up / Jira selection) and multiple tickets concurrently, self-pacing its own wake-up interval via `/loop`

Fully config-driven (repo, Slack channel, Jira project all live in a per-project `config.json`) so it's not tied to one codebase.

## Checklist

- [x] Addresses a real use case (unattended PR review + Jira backlog automation)
- [x] Doesn't duplicate existing entries in this list
- [x] Plugin repo has a valid `.claude-plugin/plugin.json` + `marketplace.json` (passes `claude plugin validate`)
- [x] README documents install, config, and safety model

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019iotjX8h7dvqQJGNCDndY4