### PR TITLE
Add swarmery to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [swarmery](https://github.com/atretyak1985/swarmery) - Local-first control plane for Claude Code. A single Go binary indexes every session on the machine, shows live tool calls, cost, and diffs, routes permission prompts to one approvals queue, and dispatches board tasks to headless agents in git worktrees. Ships a plugin marketplace (core + opt-in domain packs). No cloud, no account, no telemetry. ([Website](https://atretyak1985.github.io/swarmery/))
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds [swarmery](https://github.com/atretyak1985/swarmery) to the Developer Productivity section.

**What it does:** A local-first control plane for Claude Code. One Go binary indexes the session transcripts Claude Code already writes under `~/.claude/projects/`, serves a dashboard on `:7777` with live tool calls, cost and diffs per session, routes permission prompts from every terminal into a single approvals queue, and dispatches board tasks to headless agents running in git worktrees. The same repo is a Claude Code plugin marketplace: `core` (13 agents, 36 skills, 8 commands, hooks) plus 11 opt-in domain packs (web, infra, IoT, UAV, Jira, architecture, design, and others). Nothing leaves the machine: no cloud, no account, no telemetry. Framework Apache-2.0; control plane PolyForm Noncommercial.

Install: `/plugin marketplace add atretyak1985/swarmery` then `/plugin install core@swarmery`.
Demo (40 s): https://github.com/atretyak1985/swarmery/raw/main/docs/screenshots/demo.gif

Proof of work:
- 1 file changed, 1 insertion(+) (README.md)
- Not a duplicate: no existing entry covers session indexing, an approvals queue, or worktree dispatch.
