### PR TITLE
Add agents_control to Developer Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) - Code intelligence MCP server that builds knowledge graphs from source code with 42-language tree-sitter AST parsing and FalkorDB.
 - [agntk](https://github.com/Phoenixrr2113/agntk) - Zero-config AI agent CLI with persistent named agents, 20+ built-in tools, and hardware-aware local model selection.
 - [backlog](https://github.com/backloghq/backlog) - Persistent, cross-session task management. 24 MCP tools for tasks, projects, tags, dependencies, and docs. 7 skills for planning, standups, and handoffs. Event-sourced storage, agent coordination, pure TypeScript. ([Website](https://backloghq.io))
+- [agents_control](https://github.com/saparjohnick/agents_control) - Relays Claude Code's stop/question/permission-request hooks to Telegram with reply buttons, so you can answer from your phone instead of the keyboard. Also a remote for the terminal itself: list tabs, view screens, run commands (including interactive ones like `git add -p`). iTerm2/tmux, macOS + Linux.
 
 ### Companion & Personality
 


### PR DESCRIPTION
Adds agents_control under Developer Productivity, alongside the other externally-linked tools in that section.

agents_control relays Claude Code's stop/question/permission-request hooks to Telegram with reply buttons (answering unblocks the session through the same hook that paused it), and separately gives remote control over the terminal — list tabs, view screens, run commands including interactive ones like `git add -p`.

Repo: https://github.com/saparjohnick/agents_control