### PR TITLE
Add Verdict to Code Quality & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 - [test-writer-fixer](./test-writer-fixer) - Automatically write and fix unit tests. Supports Jest, Vitest, Pytest, and more.
 - [debugger](./debugger) - Advanced debugging assistant for tracking down and fixing complex bugs.
 - [bug-fix](./bug-fix) - Analyzes stack traces and code to identify and fix bugs in your codebase.
+- [Verdict](https://github.com/ArtJack/verdict) - A skeptical QA agent with memory: baseline → delta runs (`NEW/REGRESSED/RESOLVED`), every red test classified, flaky tests quarantined with an expiry, evidence-cited verdicts. Read-only on your code; ships an MCP server over its state, a CI release gate, and a scored eval suite with published misses.
 
 ### Backend & Architecture
 


### PR DESCRIPTION
Adds [Verdict](https://github.com/ArtJack/verdict), a QA agent plugin for Claude Code, to the Code Quality & Testing section as an external entry (same shape as AgentLint).

What it is: a QA agent with memory. A state file carries the baseline, so every run is a delta (NEW / STILL_OPEN / RESOLVED / REGRESSED); every red test is classified (real defect, stale expectation, brittle, environment, flaky with a quarantine expiry); every run ends in pass / pass with risks / blocked / fail with a stated not-tested list. It never edits the code it judges: no Edit tool, a write-scope hook, a strict-mode Bash guard. Ships a read-only MCP server over the QA state, an exit-code CI release gate, and a scored eval suite with published misses.

Real use case: release-risk review before a merge and nightly delta QA. Tested: it audits its own releases every night and has filed 79 findings against itself; a run on pallets/itsdangerous found nine proven issues. MIT, Python 3.9+, stdlib only, no network, no telemetry.

Install: `/plugin marketplace add ArtJack/verdict` then `/plugin install verdict@verdict`.