### PR TITLE
Add handrail (fail-closed deny/ask hooks) to Documentation & Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Documentation & Security
 
 - [documentation-generator](./documentation-generator) - Generate comprehensive documentation from code. READMEs, API docs, and guides.
+- [handrail](https://github.com/trimkeep/claude-plugins) - Marketplace plugin for Handrail's fail-closed deny/ask hooks for Claude Code and other agent CLIs.
 - [security-guidance](./security-guidance) - Security best practices and vulnerability detection. OWASP guidelines and secure coding.
 - [security-sweep](https://github.com/Onome-AJ/security-sweep-plugin) - Comprehensive security scanner covering OWASP Top 10 (2025), Mobile Top 10 (2024), and LLM Top 10 (2025). Scans for hardcoded secrets, injection flaws, auth issues, misconfigurations, and AI-specific vulnerabilities.
 - [asqav-claude-code](https://github.com/jagmarques/asqav-claude-code) - Signs a tamper-evident Asqav receipt at the end of each Claude Code session: files edited (content hashes before/after), commands run (hashed), and git context. Verifiable by anyone at asqav.com/verify.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Claude Plugins are extensions that enhance Claude Code with custom slash command
 ### Documentation & Security
 
 - [documentation-generator](./documentation-generator) - Generate comprehensive documentation from code. READMEs, API docs, and guides.
-- [handrail](https://github.com/trimkeep/claude-plugins) - Marketplace plugin for Handrail's fail-closed deny/ask hooks for Claude Code and other agent CLIs.
+- [handrail](https://github.com/trimkeep/claude-plugins) - Marketplace plugin for Handrail's fail-closed deny/ask hooks for Claude Code.
 - [security-guidance](./security-guidance) - Security best practices and vulnerability detection. OWASP guidelines and secure coding.
 - [security-sweep](https://github.com/Onome-AJ/security-sweep-plugin) - Comprehensive security scanner covering OWASP Top 10 (2025), Mobile Top 10 (2024), and LLM Top 10 (2025). Scans for hardcoded secrets, injection flaws, auth issues, misconfigurations, and AI-specific vulnerabilities.
 - [asqav-claude-code](https://github.com/jagmarques/asqav-claude-code) - Signs a tamper-evident Asqav receipt at the end of each Claude Code session: files edited (content hashes before/after), commands run (hashed), and git context. Verifiable by anyone at asqav.com/verify.


### PR DESCRIPTION
Adds the handrail plugin (marketplace repo trimkeep/claude-plugins; source and tests at trimkeep/handrail-kit) under Documentation & Security.

Six deny/ask rules for Claude Code hooks that fail closed on malformed input and only tighten existing permissions. MIT.

Disclosure: I maintain this project. Handrail is not affiliated with, endorsed by, or a product of Anthropic.